### PR TITLE
mx.data.action should have only one parameter

### DIFF
--- a/src/MicroflowTimer/widget/MicroflowTimer.js
+++ b/src/MicroflowTimer/widget/MicroflowTimer.js
@@ -120,7 +120,7 @@ require([
                     error: function (error) {
                         console.warn('Error executing mf: ', error);
                     }
-                }, this);
+                });
         }
     });
 });


### PR DESCRIPTION
Scope parameter does not exist in mx.data.action 
Callback uses 'self' for reference.