### PR TITLE
Flag to enable or disable microflow execution error pop-up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MicroflowTimer",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "",
   "license": "",
   "author": "",

--- a/src/MicroflowTimer/MicroflowTimer.xml
+++ b/src/MicroflowTimer/MicroflowTimer.xml
@@ -65,7 +65,7 @@
                 <attributeType name="Boolean"/>
             </attributeTypes>
         </property>
-		<property key="showerrorpopup" type="boolean" defaultValue="false">
+		<property key="showerrorpopup" type="boolean" defaultValue="true">
             <caption>Show error in a pop-up</caption>
             <category>Behavior</category>
             <description>If true, the microflow or nanoflow execution errors will be shown in a pop-up.</description>

--- a/src/MicroflowTimer/MicroflowTimer.xml
+++ b/src/MicroflowTimer/MicroflowTimer.xml
@@ -65,5 +65,10 @@
                 <attributeType name="Boolean"/>
             </attributeTypes>
         </property>
+		<property key="showerrorpopup" type="boolean" defaultValue="false">
+            <caption>Show error in a pop-up</caption>
+            <category>Behavior</category>
+            <description>If true, the microflow or nanoflow execution errors will be shown in a pop-up.</description>
+        </property>
     </properties>
 </widget>

--- a/src/MicroflowTimer/widget/MicroflowTimer.js
+++ b/src/MicroflowTimer/widget/MicroflowTimer.js
@@ -18,6 +18,7 @@ define([
         firstIntervalAttr: null,
         intervalAttr: null,
         timerStatusAttr: null,
+		showerrorpopup: false,
 
         // Internal variables. Non-primitives created in the prototype are shared between all widget instances.
         _handles: null,
@@ -198,7 +199,9 @@ define([
                     }),
                     error: lang.hitch(this, function(error) {
                         logger.error(this.id + ": An error ocurred while executing microflow: ", error);
-                        mx.ui.error("An error ocurred while executing microflow" + error.message);
+						if (this.showerrorpopup) {
+                            mx.ui.error("An error ocurred while executing microflow" + error.message);
+                        }
                     })
                 };
 
@@ -228,7 +231,9 @@ define([
                     }),
                     error: lang.hitch(this, function(error) {
                         logger.error(this.id + ": An error ocurred while executing nanoflow: ", error);
-                        mx.ui.error("An error ocurred while executing nanoflow" + error.message);
+						if (this.showerrorpopup) {
+                            mx.ui.error("An error ocurred while executing nanoflow" + error.message);
+                        }
                     })
                 });
             }

--- a/src/MicroflowTimer/widget/MicroflowTimer.js
+++ b/src/MicroflowTimer/widget/MicroflowTimer.js
@@ -18,7 +18,7 @@ define([
         firstIntervalAttr: null,
         intervalAttr: null,
         timerStatusAttr: null,
-		showerrorpopup: false,
+		showerrorpopup: true,
 
         // Internal variables. Non-primitives created in the prototype are shared between all widget instances.
         _handles: null,


### PR DESCRIPTION
In the newer version, all the microflow or nanoflow execution errors are logged in the console and are also shown in a pop-up.
This becomes a little annoying when the timer widget is used to refresh the content on a page, the page will be filled with pop-ups in case of temporary issues in the backend server.
In certain cases, it would be nice to have a feature to enable or disable the pop-up.
This pull request has those changes.
Request to have a look and merge if its found useful.